### PR TITLE
Convert patientId into a string.

### DIFF
--- a/src/fetch_patient_data.js
+++ b/src/fetch_patient_data.js
@@ -1,6 +1,8 @@
 const _ = require('lodash')
 const FetchSheet = require('./fetch_sheet.js')
 
+const numberPattern = /[0-9]+$/
+
 // Post processes the data to normalize field names etc.
 const postProcessData = (rawData) => {
 
@@ -17,16 +19,33 @@ const postProcessData = (rawData) => {
       return parseInt(n)
     }
 
-    const unspecifiedToBlank = v => {
-      if (v == 'Unspecified') return ''
-      return v
+    // Converts the number into a string, if possible.
+    const normalizeId = n => {
+      // Check if it has any number in it
+      if (n == '') { return -1 }
+      // Check if it has any number in it.
+      if (numberPattern.test(n)) {
+        return n
+      }
+      return -1
+    }
+
+    // Converts Gender
+    const normalizeGender = v => {
+      if (v == 'm' || v == 'M') {
+        return 'M'
+      }
+      if (v == 'f' || v == 'F') {
+        return 'F'
+      }
+      return ''
     }
 
     let transformedRow = {
-      'patientId': normalizeNumber(row.patientNumber),
+      'patientId': normalizeId(row.patientNumber),
       'dateAnnounced': row.dateAnnounced,
       'ageBracket': normalizeNumber(row.ageBracket),
-      'gender': unspecifiedToBlank(row.gender),
+      'gender': normalizeGender(row.gender),
       'residence': row.residenceCityPrefecture,
       'detectedCityTown': row.detectedCity,
       'detectedPrefecture': row.detectedPrefecture,
@@ -71,7 +90,7 @@ const postProcessData = (rawData) => {
     })
 
     // Add a field to indicate whether we count as patient or not.
-    transformedRow.confirmedPatient = (transformedRow.patientId > 0)
+    transformedRow.confirmedPatient = (transformedRow.patientId != -1)
 
     return transformedRow
   }

--- a/src/merge_patients.js
+++ b/src/merge_patients.js
@@ -11,7 +11,7 @@ const mergePatients = (patientLists) => {
 
   let merged = _.flatten(patientLists)
   let patientsWithoutIds = _.filter(merged, v => { return (v.patientId == -1)})
-  let patientsWithIds = _.uniqBy(_.sortBy(_.filter(merged, v => { return (v.patientId > 0)}), sortOrder), 'patientId')
+  let patientsWithIds = _.uniqBy(_.sortBy(_.filter(merged, v => { return (v.patientId != -1)}), sortOrder), 'patientId')
   //  let patientsWithIds = _.sortBy(_.filter(merged, v => { return (v.patientId != -1)}), sortOrder)
   return _.flatten([patientsWithIds, patientsWithoutIds])
 }


### PR DESCRIPTION
Moving to the possibility that the patientId is no longer a number, but can optionally be a string.

e.g. TOK107, OSK109, 1080

This to prepare for splitting of the spreadsheet to per-prefecture IDs.