### PR TITLE
Generate active chart, use viewBox for SVG size def.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2223,6 +2223,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "create-ecdh": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
@@ -5933,8 +5942,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
     "watch": "npx webpack --watch --config webpack.dev.js",
     "start": "node server.js",
     "deploy": "firebase deploy --only hosting:covid19japan-data",
-    "deploy-functions": "cd proxy && firebase deploy --only functions"
+    "deploy-functions": "cd proxy && firebase deploy --only functions",
+    "generate-charts": "node generate_charts.js"
   },
   "dependencies": {
     "@babel/core": "^7.9.0",
     "cheerio": "^1.0.0-rc.3",
+    "cors": "^2.8.5",
     "d3": "^5.16.0",
     "d3-node": "^2.2.1",
     "encoding-japanese": "^1.0.30",

--- a/server.js
+++ b/server.js
@@ -1,7 +1,9 @@
 /* eslint-disable no-console */
 const express = require('express')
-
+const cors = require('cors');
 const app = express()
+
+app.use(cors())
 app.use(express.static('docs'))
 
 let port = process.env.PORT || 3999

--- a/src/charts.js
+++ b/src/charts.js
@@ -19,13 +19,15 @@ const rollingAverage = (values, size, key) => {
   return averagedValues
 }
 
-const svgSparklineWithData = (values, width, height) => {
+const svgSparklineWithData = (values, width, height, padding) => {
   const d3n = new D3Node()      // initializes D3 with container element
   const d3 = d3n.d3
-  const margin =  {top: 10, right: 10, bottom: 10, left: 10}
+  if (!padding) {
+    padding = {top: 10, right: 10, bottom: 10, left: 10}
+  }
 
-  const chartWidth = width - margin.right - margin.left
-  const chartHeight = height - margin.top - margin.bottom;
+  const chartWidth = width - padding.right - padding.left
+  const chartHeight = height - padding.top - padding.bottom;
 
   var parseTime = d3.timeParse("%Y-%m-%d");
   values.forEach(d => { d.date = parseTime(d.date); d.value = +d.value })
@@ -47,9 +49,10 @@ const svgSparklineWithData = (values, width, height) => {
     .y1(function(d) { return y(d.value); })
     .curve(d3.curveMonotoneX)
 
-  var svg = d3n.createSVG(width, height)
+  var svg = d3n.createSVG()
+    .attr('viewBox', `0 0 ${width} ${height}`)    
     .append('g')
-    .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')')
+    .attr('transform', 'translate(' + padding.left + ',' + padding.top + ')')
 
   svg.append("path")
     .data([values])
@@ -88,7 +91,8 @@ const svgBarChartWithData = (values, width, height, maxY, fillColor) => {
   x.domain(d3.range(values.length)).padding(0.01);
   y.domain([0, maxY]);
 
-  var svg = d3n.createSVG(width, height)
+  var svg = d3n.createSVG()
+    .attr('viewBox', `0 0 ${width} ${height}`)    
     .append('g')
     .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')')
 


### PR DESCRIPTION
Using viewbox allows the SVG to be sized through CSS on the front-end.

Generate the active chart along.

Minimize padding for the line charts.