### PR TITLE
Charts axis uses absolute max value as label rather than average.

### DIFF
--- a/generate_charts.js
+++ b/generate_charts.js
@@ -5,13 +5,14 @@ const _ = require('lodash')
 const charts = require('./src/charts.js')
 
 
-const drawLineChart = (values, name, lastValueLabel) => {
+const drawLineChart = (values, name, absValues) => {
   const options = {
     padding: {top: 20, bottom: 0, left: 0, right: 0},
     showCeilingValue: true,
     showLastValue: false,
-    lastValueLabel: lastValueLabel, 
+    absValues: absValues ? absValues : values
   }
+
   const svg = charts.svgSparklineWithData(values, 180, 60, options)
   fs.writeFileSync(`./docs/charts/${name}.svg`, svg)
 }
@@ -54,8 +55,8 @@ const drawDailyLineCharts = (dailySummaries, duration) => {
     const avgValues = _.slice(charts.rollingAverage(values, avgPeriod, 'value'), values.length - duration)
     values = _.slice(values, values.length - duration)
     let lastValue = _.last(values)
-    drawLineChart(values, `${chartValue}_daily`, lastValue.value)
-    drawLineChart(avgValues, `${chartValue}_daily_avg`, lastValue.value)
+    drawLineChart(values, `${chartValue}_daily`)
+    drawLineChart(avgValues, `${chartValue}_daily_avg`, values)
   }
 
   for (let chartValue of dailyCharts) {
@@ -63,8 +64,8 @@ const drawDailyLineCharts = (dailySummaries, duration) => {
     const avgValues = _.slice(charts.rollingAverage(values, avgPeriod, 'value'), values.length - duration)
     values = _.slice(values, values.length - duration)
     let lastValue = _.last(values)
-    drawLineChart(values, `${chartValue}_cumulative`, lastValue.value)
-    drawLineChart(avgValues, `${chartValue}_cumulative_avg`, lastValue.value)
+    drawLineChart(values, `${chartValue}_cumulative`)
+    drawLineChart(avgValues, `${chartValue}_cumulative_avg`, values)
   }
 }
 

--- a/src/charts.js
+++ b/src/charts.js
@@ -117,10 +117,17 @@ const svgSparklineWithData = (values, width, height, options) => {
       return parseInt(Math.floor((v * 1.3)/10) * 10)
     };
 
+ 
     const ceilingValue = roundUp(valueMax)
     const ceilingY = y(ceilingValue)
     const linePoints = [[chartWidth - ceilingLineLength, ceilingY], [chartWidth, ceilingY]]
     const ceiling = d3.line()(linePoints)
+
+    let ceilingDisplayValue = ceilingValue
+    if (options.absValues) {
+      ceilingDisplayValue = roundUp(d3.max(options.absValues, d => d.value))
+    }
+
     svg.append('path')
       .attr('class', 'axis-ceiling')
       .attr('stroke-width', '1')
@@ -135,7 +142,7 @@ const svgSparklineWithData = (values, width, height, options) => {
       .attr('font-size', `${labelFontSize}px`)
       .attr('x', chartWidth - ceilingLineLength - ceilingLabelMargin)
       .attr('y', ceilingY + (labelFontSize / 4) )
-      .text(ceilingValue)
+      .text(ceilingDisplayValue)
   }
   return d3n.svgString()
 }


### PR DESCRIPTION
When comparing the chart to the number at the top, the average max value can be way different than the absolute value. But it is confusing if the value is not similar, so instead, we use the absolute max value as the label but keep the chart using 7-day active.

<img width="201" alt="Screen Shot 2020-05-09 at 10 27 23" src="https://user-images.githubusercontent.com/72062/81460338-b219ef00-91df-11ea-82bf-1bdfef4bd634.png">

In this example, 1830 is the daily increase, but the chart's max is only 630 because we took the average. So instead we take the abs max as the label for the scale which still gives you relative numbers but more understandable (yet less accurate)