### PR TITLE
Reimplement data fetching using Google Sheets v4 JS API

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -46,6 +46,20 @@ const fetchAndSummarize = async (dateString) => {
   const prefectures = await FetchSheet.fetchRows(latestSheetId, 'Prefecture Data')
   const cruiseCounts = await FetchSheet.fetchRows(latestSheetId, 'Cruise Sum By Day')
 
+    // Merge multiple patient lists.
+  const patientListTabs = [
+    {sheetId: latestSheetId, tabs: [
+      'Patient Data', 
+      'Aichi',
+      'Chiba',
+      'Hokkaido',
+      'Kanagawa',
+      'Osaka',
+      'Saitama',
+      'Tokyo' 
+    ]}
+]
+
   // Merge multiple patient lists.
   const patientListFetches = [
     FetchPatientData.fetchPatientData(latestSheetId, 'Patient Data'),
@@ -60,7 +74,8 @@ const fetchAndSummarize = async (dateString) => {
 
   Promise.all(patientListFetches)
     .then(patientLists => {
-      let patients = MergePatients.mergePatients(patientLists)
+      let allPatients = _.flatten(patientLists)
+      let patients = MergePatients.mergePatients(allPatients)
       console.log(`Total patients fetched: ${patients.length}`)
 
       generateLastUpdated(patients)

--- a/generate.js
+++ b/generate.js
@@ -39,66 +39,81 @@ const generateLastUpdated = async (patients) => {
   return lastUpdated
 }
 
-const fetchAndSummarize = async (dateString) => {
+const fetchAndSummarize = async (dateString, useNewMethod) => {
   const latestSheetId = '1vkw_Lku7F_F3F_iNmFFrDq9j7-tQ6EmZPOLpLt-s3TY'
 
   const daily = await FetchSheet.fetchRows(latestSheetId, 'Sum By Day')
   const prefectures = await FetchSheet.fetchRows(latestSheetId, 'Prefecture Data')
   const cruiseCounts = await FetchSheet.fetchRows(latestSheetId, 'Cruise Sum By Day')
 
-    // Merge multiple patient lists.
-  const patientListTabs = [
-    {sheetId: latestSheetId, tabs: [
-      'Patient Data', 
-      'Aichi',
-      'Chiba',
-      'Hokkaido',
-      'Kanagawa',
-      'Osaka',
-      'Saitama',
-      'Tokyo' 
-    ]}
-]
+  const mergeAndOutput = (allPatients) => {
+    let patients = MergePatients.mergePatients(allPatients)
+    console.log(`Total patients fetched: ${patients.length}`)
 
-  // Merge multiple patient lists.
-  const patientListFetches = [
-    FetchPatientData.fetchPatientData(latestSheetId, 'Patient Data'),
-    FetchPatientData.fetchPatientData(latestSheetId, 'Tokyo'),
-    FetchPatientData.fetchPatientData(latestSheetId, 'Osaka'),
-    FetchPatientData.fetchPatientData(latestSheetId, 'Kanagawa'),
-    FetchPatientData.fetchPatientData(latestSheetId, 'Aichi'),
-    FetchPatientData.fetchPatientData(latestSheetId, 'Chiba'),
-    FetchPatientData.fetchPatientData(latestSheetId, 'Saitama'),
-    FetchPatientData.fetchPatientData(latestSheetId, 'Hokkaido'),
-  ]
+    generateLastUpdated(patients)
+      .then(lastUpdated => {
+        // Write patient data
+        const patientOutputFilename = `./docs/patient_data/${dateString}.json`
+        fs.writeFileSync(patientOutputFilename, JSON.stringify(patients, null, '  '))
 
-  Promise.all(patientListFetches)
-    .then(patientLists => {
-      let allPatients = _.flatten(patientLists)
-      let patients = MergePatients.mergePatients(allPatients)
-      console.log(`Total patients fetched: ${patients.length}`)
+        // Write daily and prefectural summary.
+        const summary = Summarize.summarize(patients, daily, prefectures, cruiseCounts, lastUpdated)
+        const summaryOutputFilename = `./docs/summary/${dateString}.json`
+        fs.writeFileSync(summaryOutputFilename, JSON.stringify(summary, null, '  '))
 
-      generateLastUpdated(patients)
-        .then(lastUpdated => {
-          // Write patient data
-          const patientOutputFilename = `./docs/patient_data/${dateString}.json`
-          fs.writeFileSync(patientOutputFilename, JSON.stringify(patients, null, '  '))
+        // Write minified version of daily/prefectural summary
+        const summaryMinifiedOutputFilename = `./docs/summary_min/${dateString}.json`
+        fs.writeFileSync(summaryMinifiedOutputFilename, JSON.stringify(summary))
 
-          // Write daily and prefectural summary.
-          const summary = Summarize.summarize(patients, daily, prefectures, cruiseCounts, lastUpdated)
-          const summaryOutputFilename = `./docs/summary/${dateString}.json`
-          fs.writeFileSync(summaryOutputFilename, JSON.stringify(summary, null, '  '))
+        console.log('Success.')
+      })     
+  }
 
-          // Write minified version of daily/prefectural summary
-          const summaryMinifiedOutputFilename = `./docs/summary_min/${dateString}.json`
-          fs.writeFileSync(summaryMinifiedOutputFilename, JSON.stringify(summary))
+  if (useNewMethod) {
+    const patientListTabs = [
+      { 
+        sheetId: latestSheetId, 
+        tabs: [
+          'Patient Data', 
+          'Aichi',
+          'Chiba',
+          'Hokkaido',
+          'Kanagawa',
+          'Osaka',
+          'Saitama',
+          'Tokyo' 
+        ]
+      }
+    ]
+    FetchPatientData.fetchPatientDataFromSheets(patientListTabs)
+      .then(allPatients => {
+        mergeAndOutput(allPatients)
+      })
+      .catch(error => {
+        console.log(error)
+      })
+  } else {
+    // OLD method
+    const patientListFetches = [
+      FetchPatientData.fetchPatientData(latestSheetId, 'Patient Data'),
+      FetchPatientData.fetchPatientData(latestSheetId, 'Tokyo'),
+      FetchPatientData.fetchPatientData(latestSheetId, 'Osaka'),
+      FetchPatientData.fetchPatientData(latestSheetId, 'Kanagawa'),
+      FetchPatientData.fetchPatientData(latestSheetId, 'Aichi'),
+      FetchPatientData.fetchPatientData(latestSheetId, 'Chiba'),
+      FetchPatientData.fetchPatientData(latestSheetId, 'Saitama'),
+      FetchPatientData.fetchPatientData(latestSheetId, 'Hokkaido'),
+    ]
+    Promise.all(patientListFetches)
+      .then(patientLists => {
+        let allPatients = _.flatten(patientLists)
+        mergeAndOutput(allPatients)
+      })
+      .catch(error => {
+        console.log(error)
+      })
 
-          console.log('Success.')
-        })     
-    })
-    .catch(error => {
-      console.log(error)
-    })
+  }
 }
 
 const writePerPrefecturePatients = (prefectureName, allPatients, dateString) => {
@@ -111,7 +126,7 @@ const writePerPrefecturePatients = (prefectureName, allPatients, dateString) => 
 try {
   // Add 540 = UTC+9 for JST.
   const dateString = moment().utcOffset(540).format('YYYY-MM-DD')
-  fetchAndSummarize(dateString)
+  fetchAndSummarize(dateString, false)
 } catch (e) {
   console.error(e)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1155,6 +1155,14 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -1182,6 +1190,29 @@
           "version": "4.0.13",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
           "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+        }
+      }
+    },
+    "agent-base": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
+      "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
+      "requires": {
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -1336,6 +1367,11 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
+    },
+    "arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
     },
     "asn1": {
       "version": "0.2.4",
@@ -1538,8 +1574,7 @@
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-      "dev": true
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -1554,6 +1589,11 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true
+    },
+    "bignumber.js": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
     },
     "binary-extensions": {
       "version": "1.13.1",
@@ -1759,6 +1799,11 @@
         "ieee754": "^1.1.4",
         "isarray": "^1.0.0"
       }
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -2970,6 +3015,14 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -3201,6 +3254,11 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "events": {
       "version": "3.1.0",
@@ -3436,6 +3494,11 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "fast-text-encoding": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
+      "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig=="
     },
     "figgy-pudding": {
       "version": "3.5.2",
@@ -4321,6 +4384,25 @@
         }
       }
     },
+    "gaxios": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-3.0.4.tgz",
+      "integrity": "sha512-97NmFuMETFQh6gqPUxkqjxRMjmY8aRKRMphIkgO/b90AbCt5wAVuXsp8oWjIXlLN2pIK/fsXD8edcM7ULkFMLg==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.3.0"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+        }
+      }
+    },
     "gaze": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
@@ -4328,6 +4410,15 @@
       "dev": true,
       "requires": {
         "globule": "^1.0.0"
+      }
+    },
+    "gcp-metadata": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.1.4.tgz",
+      "integrity": "sha512-5J/GIH0yWt/56R3dNaNWPGQ/zXsZOddYECfJaqxFWgrZ9HC2Kvc5vl9upOgUUHKzURjAVf2N+f6tEJiojqXUuA==",
+      "requires": {
+        "gaxios": "^3.0.0",
+        "json-bigint": "^1.0.0"
       }
     },
     "gensync": {
@@ -4456,11 +4547,102 @@
         "minimatch": "~3.0.2"
       }
     },
+    "google-auth-library": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.0.5.tgz",
+      "integrity": "sha512-Wj31lfTm2yR4g3WfOOB1Am1tt478Xq9OvzTPQJi17tn/I9R5IcsxjANBsE93nYmxYxtwDedhOdIb8l3vSPG49Q==",
+      "requires": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^3.0.0",
+        "gcp-metadata": "^4.1.0",
+        "gtoken": "^5.0.0",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "google-p12-pem": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.2.tgz",
+      "integrity": "sha512-tbjzndQvSIHGBLzHnhDs3cL4RBjLbLXc2pYvGH+imGVu5b4RMAttUTdnmW2UH0t11QeBTXZ7wlXPS7hrypO/tg==",
+      "requires": {
+        "node-forge": "^0.9.0"
+      }
+    },
+    "googleapis": {
+      "version": "56.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-56.0.0.tgz",
+      "integrity": "sha512-qf8Xp7QV7h81nWzspRCMIEnFsG6aBrsomkl0H/578G8/8lIZ/tt+6yDexVTPsR6XDo/jhSb4rtN9462AmLhQxA==",
+      "requires": {
+        "google-auth-library": "^6.0.0",
+        "googleapis-common": "^4.4.0"
+      }
+    },
+    "googleapis-common": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-4.4.0.tgz",
+      "integrity": "sha512-Bgrs8/1OZQFFIfVuX38L9t48rPAkVUXttZy6NzhhXxFOEMSHgfFIjxou7RIXOkBHxmx2pVwct9WjKkbnqMYImQ==",
+      "requires": {
+        "extend": "^3.0.2",
+        "gaxios": "^3.0.0",
+        "google-auth-library": "^6.0.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^8.0.0"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.9.4",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+          "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+        },
+        "uuid": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.2.0.tgz",
+          "integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q=="
+        }
+      }
+    },
     "graceful-fs": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
       "dev": true
+    },
+    "gtoken": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.0.2.tgz",
+      "integrity": "sha512-lull70rHCTvRTmAt+R/6W5bTtx4MjHku7AwJwK5fGqhOmygcZud0nrZcX+QUNfBJwCzqy7S5i1Bc4NYnr5PMMA==",
+      "requires": {
+        "gaxios": "^3.0.0",
+        "google-p12-pem": "^3.0.0",
+        "jws": "^4.0.0",
+        "mime": "^2.2.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.4.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
+        }
+      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -4728,6 +4910,30 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
+    },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -5137,6 +5343,14 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
+    "json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "requires": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -5176,6 +5390,25 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "requires": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "kind-of": {
@@ -5661,6 +5894,11 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
+    "node-forge": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
+      "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ=="
     },
     "node-gyp": {
       "version": "3.8.0",
@@ -8384,6 +8622,11 @@
           "dev": true
         }
       }
+    },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dotenv": "^8.2.0",
     "encoding-japanese": "^1.0.30",
     "express": "^4.17.1",
+    "googleapis": "^56.0.0",
     "lodash": "^4.17.19",
     "moment": "^2.24.0",
     "node-fetch": "^2.6.0",

--- a/src/fetch_patient_data.js
+++ b/src/fetch_patient_data.js
@@ -123,6 +123,12 @@ const postProcessData = (rows) => {
       return v
     })
 
+    // Use row.prefectureUrlAuto if that exists (for backwards compat if the spreadsheet
+    // has that column). Remove after August 2020.
+    if (row.prefectureUrlAuto && !transformedRow.prefectureSourceURL) {
+      transformedRow.prefectureSourceURL = row.prefectureUrlAuto
+    }
+
     // Add a field to indicate whether we count as patient or not.
     transformedRow.confirmedPatient = (transformedRow.patientId != -1)
 

--- a/src/fetch_sheet.js
+++ b/src/fetch_sheet.js
@@ -27,22 +27,32 @@ const sheetRowsURL = (sheetId, sheetName) => {
   return `https://sheets.googleapis.com/v4/spreadsheets/${sheetId}/values/${encodedSheetName}?key=${sheetApiKey}`
 }
 
-const fetchWithSheetsService = (sheetId, sheetName, fields) => {
+const fetchSheets = (sheetsAndTabs, fields) => {
   const sheets = google.sheets({version: 'v4', auth: getSheetApiKey()});
-  return new Promise((resolve, reject) => {
-    sheets.spreadsheets.get({
-      spreadsheetId: sheetId,
-      ranges: [sheetName],
-      fields: fields
-    }, (err, res) => {
-      if (err) {
-        reject(err)
-        return
-      }
-      //const rows = res.sheets[0];
-      resolve(res.data)
-    });
-  })
+  const requests = []
+  for (let sheetInfo of sheetsAndTabs) {
+    let tabs = sheetInfo.tabs
+    let sheetId = sheetInfo.sheetId
+
+    let request = new Promise((resolve, reject) => {
+      sheets.spreadsheets.get({
+        spreadsheetId: sheetId,
+        ranges: tabs,
+        fields: fields
+      }, (err, res) => {
+        if (err) {
+          reject(err)
+          return
+        }
+        console.log(res.data)
+        //const rows = res.sheets[0];
+        resolve(res.data)
+      });
+    })
+    requests.push(request)
+  }
+
+  return Promise.all(requests)
 }
 
 const fetchTabs = (sheetId) => {
@@ -101,4 +111,4 @@ const fetchRows = (sheetId, sheetName, headerNormalizer) => {
 
 exports.fetchTabs = fetchTabs;
 exports.fetchRows = fetchRows;
-exports.fetchWithSheetsService = fetchWithSheetsService;
+exports.fetchSheets = fetchSheets;

--- a/src/fetch_sheet.js
+++ b/src/fetch_sheet.js
@@ -9,6 +9,8 @@ const _ = require('lodash')
 const dotenv = require('dotenv')
 const {google} = require('googleapis')
 
+const DEFAULT_FIELD_MASK = 'spreadsheetId,properties,sheets.properties,sheets.data.rowData.values(effectiveValue,formattedValue,effectiveFormat.hyperlinkDisplayType,hyperlink)'
+
 // Read GOOGLE_API_KEY from .env if it exists.
 dotenv.config()
 
@@ -27,9 +29,13 @@ const sheetRowsURL = (sheetId, sheetName) => {
   return `https://sheets.googleapis.com/v4/spreadsheets/${sheetId}/values/${encodedSheetName}?key=${sheetApiKey}`
 }
 
+// Use the v4 JS API to fetch sheet data.
 const fetchSheets = (sheetsAndTabs, fieldMask) => {
   const sheets = google.sheets({version: 'v4', auth: getSheetApiKey()});
   const requests = []
+  if (!fieldMask) {
+    fieldMask = DEFAULT_FIELD_MASK
+  }
   for (let sheetInfo of sheetsAndTabs) {
     let tabs = sheetInfo.tabs
     let sheetId = sheetInfo.sheetId

--- a/src/fetch_sheet.js
+++ b/src/fetch_sheet.js
@@ -7,6 +7,7 @@ const process = require('process')
 const fetch = require('node-fetch')
 const _ = require('lodash')
 const dotenv = require('dotenv')
+const {google} = require('googleapis')
 
 // Read GOOGLE_API_KEY from .env if it exists.
 dotenv.config()
@@ -24,6 +25,24 @@ const sheetRowsURL = (sheetId, sheetName) => {
   const sheetApiKey = getSheetApiKey()
   const encodedSheetName = encodeURIComponent(sheetName)
   return `https://sheets.googleapis.com/v4/spreadsheets/${sheetId}/values/${encodedSheetName}?key=${sheetApiKey}`
+}
+
+const fetchWithSheetsService = (sheetId, sheetName, fields) => {
+  const sheets = google.sheets({version: 'v4', auth: getSheetApiKey()});
+  return new Promise((resolve, reject) => {
+    sheets.spreadsheets.get({
+      spreadsheetId: sheetId,
+      ranges: [sheetName],
+      fields: fields
+    }, (err, res) => {
+      if (err) {
+        reject(err)
+        return
+      }
+      //const rows = res.sheets[0];
+      resolve(res.data)
+    });
+  })
 }
 
 const fetchTabs = (sheetId) => {
@@ -82,3 +101,4 @@ const fetchRows = (sheetId, sheetName, headerNormalizer) => {
 
 exports.fetchTabs = fetchTabs;
 exports.fetchRows = fetchRows;
+exports.fetchWithSheetsService = fetchWithSheetsService;

--- a/src/merge_patients.js
+++ b/src/merge_patients.js
@@ -1,21 +1,16 @@
 const _ = require('lodash')
 const Verify = require('./verify.js')
 
-const mergePatients = (patientLists) => {
+const mergePatients = (allPatients) => {
   //const sortOrder = ['patientId', 'dateAnnounced']
   const sortOrder = ['dateAnnounced', 'patientId']
 
-  Verify.verifyPatientLists(patientLists)
-  
-  for (let patients of patientLists) {
-    Verify.verifyPatients(patients)
-  }
-
-  let merged = _.flatten(patientLists)
-  let patientsWithoutIds = _.sortBy(_.filter(merged, v => { return (v.patientId == -1)}), ['dateAnnounced'])
-  let patientsWithIds = _.uniqBy(_.sortBy(_.filter(merged, v => { return (v.patientId != -1)}), sortOrder), 'patientId')
+  Verify.verifyPatients(allPatients)
+  let patientsWithoutIds = _.sortBy(_.filter(allPatients, v => { return (v.patientId == -1)}), ['dateAnnounced'])
+  let patientsWithIds = _.uniqBy(_.sortBy(_.filter(allPatients, v => { return (v.patientId != -1)}), sortOrder), 'patientId')
   //  let patientsWithIds = _.sortBy(_.filter(merged, v => { return (v.patientId != -1)}), sortOrder)
   return _.flatten([patientsWithIds, patientsWithoutIds])
 }
+
 
 exports.mergePatients = mergePatients

--- a/src/merge_patients.js
+++ b/src/merge_patients.js
@@ -8,7 +8,6 @@ const mergePatients = (allPatients) => {
   Verify.verifyPatients(allPatients)
   let patientsWithoutIds = _.sortBy(_.filter(allPatients, v => { return (v.patientId == -1)}), ['dateAnnounced'])
   let patientsWithIds = _.uniqBy(_.sortBy(_.filter(allPatients, v => { return (v.patientId != -1)}), sortOrder), 'patientId')
-  //  let patientsWithIds = _.sortBy(_.filter(merged, v => { return (v.patientId != -1)}), sortOrder)
   return _.flatten([patientsWithIds, patientsWithoutIds])
 }
 

--- a/src/verify.js
+++ b/src/verify.js
@@ -48,7 +48,11 @@ const verifyPatients = (patients) => {
   }
 
   if (duplicates.length > 0) {
-    throw new Error(`PatientError: Duplicated patientIds detected ${duplicates}`)
+    if (duplicates.length > 1000) {
+      throw new Error(`PatientError: Duplicated patientIds detected: Total: ${duplicates.length}: First: ${duplicates[0]} `)
+    } else {
+      throw new Error(`PatientError: Duplicated patientIds detected: ${duplicates}: `)
+    }
   }
 
   return patients

--- a/test.js
+++ b/test.js
@@ -9,25 +9,23 @@ const FetchPatient = require('./src/fetch_patient_data.js')
 // verify.verifyDailySummary(summary.daily)
 // console.log(summary.daily[summary.daily.length - 1])
 
-const fieldMask = "sheets.data.rowData.values(effectiveValue,formattedValue,effectiveFormat.hyperlinkDisplayType,hyperlink)"
+const fieldMask = 'spreadsheetId,properties,sheets.properties,sheets.data.rowData.values(effectiveValue,formattedValue,effectiveFormat.hyperlinkDisplayType,hyperlink)'
+
 const sheetsAndTabs = [
   {sheetId: '1vkw_Lku7F_F3F_iNmFFrDq9j7-tQ6EmZPOLpLt-s3TY', tabs: ['Patient Data', 'Aichi']}
 ]
 
-FetchPatient.fetchPatientDataFromSheets(sheetsAndTabs)
-  .then(patients => {
-    console.log(patients)
+// FetchPatient.fetchPatientDataFromSheets(sheetsAndTabs)
+//   .then(patients => {
+//     console.log(patients)
+//   })
+
+FetchSheet.fetchSheets(sheetsAndTabs, fieldMask)
+  .then((responses) => {
+    for (let sheetsResponse of responses) {
+//      console.log(sheetsResponse)
+    }
   })
-
-// FetchSheet.fetchSheets(sheetsAndTabs, fieldMask)
-//   .then((responses) => {
-//     for (let sheetsResponse of responses) {
-//       for (let rows of sheetsResponse) {
-//         console.log(rows[2])
-//       }
-//     }
-
-//   })
-//   .catch((err) => {
-//     console.error(err)
-//   })
+  .catch((err) => {
+    console.error(err)
+  })

--- a/test.js
+++ b/test.js
@@ -2,7 +2,19 @@ const fs = require('fs')
 const _ = require('lodash')
 const Papa = require('papaparse')
 const verify = require('./src/verify.js')
+const FetchSheet = require('./src/fetch_sheet.js')
 
-let summary = JSON.parse(fs.readFileSync('docs/summary/latest.json'))
-verify.verifyDailySummary(summary.daily)
-console.log(summary.daily[summary.daily.length - 1])
+// let summary = JSON.parse(fs.readFileSync('docs/summary/latest.json'))
+// verify.verifyDailySummary(summary.daily)
+// console.log(summary.daily[summary.daily.length - 1])
+
+const fields = "sheets.data.rowData.values(effectiveValue,formattedValue,effectiveFormat.hyperlinkDisplayType,hyperlink)"
+
+FetchSheet.fetchWithSheetsService('1vkw_Lku7F_F3F_iNmFFrDq9j7-tQ6EmZPOLpLt-s3TY', 'Patient Data', fields)
+  .then((response) => {
+    console.log(response.sheets)
+    console.log(response.sheets[0].data[0].rowData[146].values)
+  })
+  .catch((err) => {
+    console.error(err)
+  })

--- a/test.js
+++ b/test.js
@@ -9,11 +9,18 @@ const FetchSheet = require('./src/fetch_sheet.js')
 // console.log(summary.daily[summary.daily.length - 1])
 
 const fields = "sheets.data.rowData.values(effectiveValue,formattedValue,effectiveFormat.hyperlinkDisplayType,hyperlink)"
+const sheetsAndTabs = [
+  {sheetId: '1vkw_Lku7F_F3F_iNmFFrDq9j7-tQ6EmZPOLpLt-s3TY', tabs: ['Patient Data', 'Aichi']}
+]
 
-FetchSheet.fetchWithSheetsService('1vkw_Lku7F_F3F_iNmFFrDq9j7-tQ6EmZPOLpLt-s3TY', 'Patient Data', fields)
-  .then((response) => {
-    console.log(response.sheets)
-    console.log(response.sheets[0].data[0].rowData[146].values)
+FetchSheet.fetchSheets(sheetsAndTabs, fields)
+  .then((responses) => {
+    for (let response of responses) {
+      for (let sheet of response.sheets) {
+        console.log(sheet.data[0].rowData[146].values)
+      }
+    }
+
   })
   .catch((err) => {
     console.error(err)

--- a/test.js
+++ b/test.js
@@ -3,25 +3,31 @@ const _ = require('lodash')
 const Papa = require('papaparse')
 const verify = require('./src/verify.js')
 const FetchSheet = require('./src/fetch_sheet.js')
+const FetchPatient = require('./src/fetch_patient_data.js')
 
 // let summary = JSON.parse(fs.readFileSync('docs/summary/latest.json'))
 // verify.verifyDailySummary(summary.daily)
 // console.log(summary.daily[summary.daily.length - 1])
 
-const fields = "sheets.data.rowData.values(effectiveValue,formattedValue,effectiveFormat.hyperlinkDisplayType,hyperlink)"
+const fieldMask = "sheets.data.rowData.values(effectiveValue,formattedValue,effectiveFormat.hyperlinkDisplayType,hyperlink)"
 const sheetsAndTabs = [
   {sheetId: '1vkw_Lku7F_F3F_iNmFFrDq9j7-tQ6EmZPOLpLt-s3TY', tabs: ['Patient Data', 'Aichi']}
 ]
 
-FetchSheet.fetchSheets(sheetsAndTabs, fields)
-  .then((responses) => {
-    for (let response of responses) {
-      for (let sheet of response.sheets) {
-        console.log(sheet.data[0].rowData[146].values)
-      }
-    }
+FetchPatient.fetchPatientDataFromSheets(sheetsAndTabs)
+  .then(patients => {
+    console.log(patients)
+  })
 
-  })
-  .catch((err) => {
-    console.error(err)
-  })
+// FetchSheet.fetchSheets(sheetsAndTabs, fieldMask)
+//   .then((responses) => {
+//     for (let sheetsResponse of responses) {
+//       for (let rows of sheetsResponse) {
+//         console.log(rows[2])
+//       }
+//     }
+
+//   })
+//   .catch((err) => {
+//     console.error(err)
+//   })


### PR DESCRIPTION
Previously we used the REST API which is fine, but it is not able to fetch the hyperlinks that are added. 

This PR introduces a new dependency (googleapis) and implements a new set of methods to fetch from the v4 API. It should have minimal effect on the existing implementation, but after landing this, we can switch to the new API that will extract all the data, including hyperlinks.

