### PR TITLE
Memory optimizations for patient counts

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -57,13 +57,13 @@ const filterPatientForOutput = (patient) => {
   if (patient.ageBracket === -1) {
     delete filtered.ageBracket;
   }
-  delete filtered.patientCount;
+  // delete filtered.patientCount;
   return filtered;
 };
 
 const mergeAndOutput = (allPatients, daily, prefectures, cruiseCounts, recoveries) => {
   const patients = MergePatients.mergePatients(allPatients);
-  console.log(`Total patients fetched: ${patients.length}`);
+  console.log(`Total patient rows fetched: ${patients.length}`);
 
   // Write patient data
   const patientOutputFilename = "./docs/patient_data/latest.json";

--- a/src/fetch_patient_data.js
+++ b/src/fetch_patient_data.js
@@ -1,229 +1,220 @@
-const _ = require('lodash')
-const FetchSheet = require('./fetch_sheet.js')
+const _ = require("lodash");
+const FetchSheet = require("./fetch_sheet.js");
 
-const numberPattern = /[0-9]+$/
-const shortDatePattern = /([0-9]+)\/([0-9]+)/
+const numberPattern = /[0-9]+$/;
+const shortDatePattern = /([0-9]+)\/([0-9]+)/;
 
 // Post processes the data to normalize field names etc.
 const postProcessData = (rows) => {
-
   // Check validity of the row.
-  const isValidRow = row => {
-    if (!row.patientId || row.patientId == '' || typeof row === 'undefined') { return false }
-    if (!row.detectedPrefecture) { return false }
-    if (!row.dateAnnounced) { return false }
-    return true
-  }
+  const isValidRow = (row) => {
+    if (!row.patientId || row.patientId == "" || typeof row === "undefined") { return false; }
+    if (!row.detectedPrefecture) { return false; }
+    if (!row.dateAnnounced) { return false; }
+    return true;
+  };
 
-  const transformRow = row => {
-    const normalizeNumber = n => {
-      if (isNaN(parseInt(n))) { return -1 }
-      return parseInt(n)
-    }
+  const transformRow = (row) => {
+    const normalizeNumber = (n) => {
+      if (isNaN(parseInt(n))) { return -1; }
+      return parseInt(n);
+    };
 
-    const normalizeDate = n => {
+    const normalizeDate = (n) => {
       if (!n) {
-        return n
+        return n;
       }
-      return normalizeFixedWidthNumbers(n.replace('ｰ', '-'))
-    }
+      return normalizeFixedWidthNumbers(n.replace("ｰ", "-"));
+    };
 
-    const normalizeFixedWidthNumbers = v => {
-      return v.replace(/０/g, '0')
-       .replace(/１/g, '1')
-       .replace(/２/g, '2')
-       .replace(/３/g, '3')
-       .replace(/４/g, '4')
-       .replace(/５/g, '5')
-       .replace(/６/g, '6')
-       .replace(/７/g, '7')
-       .replace(/８/g, '8')
-       .replace(/９/g, '9')
-    }
+    const normalizeFixedWidthNumbers = (v) => v.replace(/０/g, "0")
+      .replace(/１/g, "1")
+      .replace(/２/g, "2")
+      .replace(/３/g, "3")
+      .replace(/４/g, "4")
+      .replace(/５/g, "5")
+      .replace(/６/g, "6")
+      .replace(/７/g, "7")
+      .replace(/８/g, "8")
+      .replace(/９/g, "9");
 
     // Converts the number into a string, if possible.
-    const normalizeId = n => {
+    const normalizeId = (n) => {
       // Check if it has any number in it.
       if (numberPattern.test(n)) {
-        return n
+        return n;
       }
-      return -1
-    }
+      return -1;
+    };
 
     // Converts Gender
-    const normalizeGender = v => {
-      if (v == 'm' || v == 'M') {
-        return 'M'
+    const normalizeGender = (v) => {
+      if (v == "m" || v == "M") {
+        return "M";
       }
-      if (v == 'f' || v == 'F') {
-        return 'F'
+      if (v == "f" || v == "F") {
+        return "F";
       }
-      return ''
-    }
+      return "";
+    };
 
-    const normalizeCount = v => {
+    const normalizeCount = (v) => {
       if (!v) {
-        return 1
+        return 1;
       }
-      let intValue = parseInt(v)
+      const intValue = parseInt(v);
       if (isNaN(intValue) || !intValue) {
-        return 1
-      }      
-      return intValue
-    }
+        return 1;
+      }
+      return intValue;
+    };
 
     // Parse short date
     const parseShortDate = (v, dateHint) => {
       if (v) {
         // Use the date hint to guess which year it should be in.
-        let year = 2020
-        if (dateHint && dateHint.startsWith('202')) {
-          year = dateHint.slice(0, 4)
+        let year = 2020;
+        if (dateHint && dateHint.startsWith("202")) {
+          year = dateHint.slice(0, 4);
         }
 
-        let shortDateMatch = v.match(shortDatePattern)
+        const shortDateMatch = v.match(shortDatePattern);
         if (shortDateMatch) {
-          let month = shortDateMatch[1].padStart(2, '0')
-          let day = shortDateMatch[2].padStart(2, '0')
-          return `${year}-${month}-${day}`
+          const month = shortDateMatch[1].padStart(2, "0");
+          const day = shortDateMatch[2].padStart(2, "0");
+          return `${year}-${month}-${day}`;
         }
       }
-      return v
-    }
+      return v;
+    };
 
     let transformedRow = {
-      'patientId': normalizeId(row.patientNumber),
-      'dateAnnounced': normalizeDate(row.dateAnnounced),
-      'ageBracket': normalizeNumber(row.ageBracket),
-      'gender': normalizeGender(row.gender),
-      'residence': row.residenceCityPrefecture,
-      'detectedCityTown': row.detectedCity,
-      'detectedPrefecture': row.detectedPrefecture,
-      'patientStatus': row.status,
-      'patientCount': normalizeCount(row.count),
-      'knownCluster': row.knownCluster,
-      'relatedPatients': row.relatedPatients,
-      'mhlwPatientNumber': row.mhlwOrigPatientNumber,
-      'prefecturePatientNumber': row.prefecturePatientNumber,
-      'cityPrefectureNumber': row.cityPatientNumber,
-      'deathSourceURL': row.deathSourceURL,
-      'detectedAtPort': row.detectedAtPort,
-      'deceasedDate': parseShortDate(row.deceased, row.dateAnnounced),
-      'deceasedReportedDate': parseShortDate(row.deathReportedDate, row.dateAnnounced),
-// Temporarily not reading these columns to minimize data export size.      
-//      'notes': row.notes,
-//      'prefectureSourceURL': row.prefectureSourceURL,
-//      'citySourceURL': row.citySourceURL,
-//      'sourceURL': row.sourceS,
-//      'prefectureURL': row.prefectureURLAuto,
-//      'cityURL': row.cityURLAuto,
-//      'deathURL': row.deathURLAuto
-    }
+      patientId: normalizeId(row.patientNumber),
+      dateAnnounced: normalizeDate(row.dateAnnounced),
+      ageBracket: normalizeNumber(row.ageBracket),
+      gender: normalizeGender(row.gender),
+      residence: row.residenceCityPrefecture,
+      detectedCityTown: row.detectedCity,
+      detectedPrefecture: row.detectedPrefecture,
+      patientStatus: row.status,
+      patientCount: normalizeCount(row.count),
+      knownCluster: row.knownCluster,
+      relatedPatients: row.relatedPatients,
+      mhlwPatientNumber: row.mhlwOrigPatientNumber,
+      prefecturePatientNumber: row.prefecturePatientNumber,
+      cityPrefectureNumber: row.cityPatientNumber,
+      deathSourceURL: row.deathSourceURL,
+      detectedAtPort: row.detectedAtPort,
+      deceasedDate: parseShortDate(row.deceased, row.dateAnnounced),
+      deceasedReportedDate: parseShortDate(row.deathReportedDate, row.dateAnnounced),
+      // Temporarily not reading these columns to minimize data export size.
+      //      'notes': row.notes,
+      //      'prefectureSourceURL': row.prefectureSourceURL,
+      //      'citySourceURL': row.citySourceURL,
+      //      'sourceURL': row.sourceS,
+      //      'prefectureURL': row.prefectureURLAuto,
+      //      'cityURL': row.cityURLAuto,
+      //      'deathURL': row.deathURLAuto
+    };
 
     // filter empty cells.
     transformedRow = _.pickBy(transformedRow, (v, k) => {
-      if (v === '' || v === false || typeof v === 'undefined') {
-        return false
+      if (v === "" || v === false || typeof v === "undefined") {
+        return false;
       }
-      return true
-    })
+      return true;
+    });
 
     // Use row.prefectureUrlAuto if that exists (for backwards compat if the spreadsheet
     // has that column). Remove after August 2020.
     if (row.prefectureUrlAuto && !transformedRow.prefectureSourceURL) {
-      transformedRow.prefectureSourceURL = row.prefectureUrlAuto
+      transformedRow.prefectureSourceURL = row.prefectureUrlAuto;
     }
 
     // Add a field to indicate whether we count as patient or not.
-    transformedRow.confirmedPatient = (transformedRow.patientId != -1)
+    transformedRow.confirmedPatient = (transformedRow.patientId != -1);
 
     // If the patient is deceased, but we don't know the date they died, use the dateAnnounced for now.
-    if (transformedRow.patientStatus == 'Deceased') {
-      if (typeof transformedRow.deceasedDate === 'undefined' || !transformedRow.deceasedDate) {
-        transformedRow.deceasedDate = transformedRow.dateAnnounced
+    if (transformedRow.patientStatus == "Deceased") {
+      if (typeof transformedRow.deceasedDate === "undefined" || !transformedRow.deceasedDate) {
+        transformedRow.deceasedDate = transformedRow.dateAnnounced;
       }
     }
 
-    return transformedRow
-  }
+    return transformedRow;
+  };
 
   // Expand rows if the patient count is more than 1
   const expandRows = (row) => {
     if (row.patientCount <= 1) {
-      return [row]
+      return [row];
     }
 
-    let expandedPatients = []
+    const expandedPatients = [];
     for (let i = 0; i < row.patientCount; i++) {
-      let patient = Object.assign({}, row) // copy
-      delete patient.patientCount
+      const patient = { ...row }; // copy
+      delete patient.patientCount;
       if (patient.patientId != -1) {
-        patient.patientId = `${patient.patientId}.${i}`
+        patient.patientId = `${patient.patientId}.${i}`;
       }
-      expandedPatients.push(patient)
+      expandedPatients.push(patient);
     }
-    return expandedPatients
-  }
+    return expandedPatients;
+  };
 
-  const filteredRows = _.filter(_.map(rows, transformRow), isValidRow)
-  const expandedRows = filteredRows.map(expandRows).reduce((flattened, other) => flattened.concat(other))
-  return expandedRows
-}
+  const filteredRows = _.filter(_.map(rows, transformRow), isValidRow);
+  // Don't expand rows any more, modify our code to deal with patientCount.
+  // const expandedRows = filteredRows.map(expandRows).reduce((flattened, other) => flattened.concat(other));
+  return filteredRows;
+};
 
 const valuesFromCellObject = (cellObjectRows) => {
   const rowTransformer = (row) => {
-    let transformed = {}
-    for (let k of _.keys(row)) {
-      let v = row[k]
-      transformed[k] = v.formattedValue
+    const transformed = {};
+    for (const k of _.keys(row)) {
+      const v = row[k];
+      transformed[k] = v.formattedValue;
 
-      if (k == 'prefecturePatientNumber' && v.hyperlink) {
-        transformed['prefectureSourceURL'] = v.hyperlink
+      if (k == "prefecturePatientNumber" && v.hyperlink) {
+        transformed.prefectureSourceURL = v.hyperlink;
       }
-      if (k == 'cityPatientNumber' && v.hyperlink) {
-        transformed['citySourceURL'] = v.hyperlink
+      if (k == "cityPatientNumber" && v.hyperlink) {
+        transformed.citySourceURL = v.hyperlink;
       }
-      if (k == 'deceased' && v.hyperlink) {
-        transformed['deathSourceURL'] = v.hyperlink
+      if (k == "deceased" && v.hyperlink) {
+        transformed.deathSourceURL = v.hyperlink;
       }
-      if (k == 'deathReportedDate' && v.hyperlink) {
-        transformed['deathSourceURL'] = v.hyperlink
+      if (k == "deathReportedDate" && v.hyperlink) {
+        transformed.deathSourceURL = v.hyperlink;
       }
     }
-    return transformed
-  }
+    return transformed;
+  };
 
   const isValidRow = (row) => {
-    if (!row) { return false }
-    if (typeof row.patientNumber === 'undefined' || row.patientNumber == '') { return false }
-    return true
-  }
+    if (!row) { return false; }
+    if (typeof row.patientNumber === "undefined" || row.patientNumber == "") { return false; }
+    return true;
+  };
 
-  return _.filter(_.map(cellObjectRows, rowTransformer), isValidRow)
-}
+  return _.filter(_.map(cellObjectRows, rowTransformer), isValidRow);
+};
 
-
-const fetchPatientData = async (sheetId, sheetName) => {
-  return FetchSheet.fetchRows(sheetId, sheetName)
-    .then(data => {
-      return postProcessData(data)
-    })
-}
+const fetchPatientData = async (sheetId, sheetName) => FetchSheet.fetchRows(sheetId, sheetName)
+  .then((data) => postProcessData(data));
 
 // Fetching using the new fetchSheets API.
-const fetchPatientDataFromSheets = async (sheets) => {
-  return FetchSheet.fetchSheets(sheets)
-    .then(responses => {
-      let allPatients = []
-      for (let sheets of responses) {
-        for (let rowsOfSheet of sheets) {
-          const patients = postProcessData(valuesFromCellObject(rowsOfSheet))
-          allPatients = allPatients.concat(patients)
-        }
+const fetchPatientDataFromSheets = async (sheets) => FetchSheet.fetchSheets(sheets)
+  .then((responses) => {
+    let allPatients = [];
+    for (const sheets of responses) {
+      for (const rowsOfSheet of sheets) {
+        const patients = postProcessData(valuesFromCellObject(rowsOfSheet));
+        allPatients = allPatients.concat(patients);
       }
-      return allPatients
-    })
-}
+    }
+    return allPatients;
+  });
 
 exports.fetchPatientData = fetchPatientData;
 exports.fetchPatientDataFromSheets = fetchPatientDataFromSheets;

--- a/src/summarize.js
+++ b/src/summarize.js
@@ -84,7 +84,7 @@ const generateDailySummary = (patients, manualDailyData, prefectureSummary, crui
       if (!dailySummary[dateAnnounced]) {
         dailySummary[dateAnnounced] = _.assign({}, DAILY_SUMMARY_TEMPLATE);
       }
-      dailySummary[dateAnnounced].confirmed += 1;
+      dailySummary[dateAnnounced].confirmed += patient.patientCount || 1;
     }
 
     if (patient.patientStatus == "Deceased") {
@@ -105,14 +105,14 @@ const generateDailySummary = (patients, manualDailyData, prefectureSummary, crui
         if (!dailySummary[dateDeceased]) {
           dailySummary[dateDeceased] = _.assign({}, DAILY_SUMMARY_TEMPLATE);
         }
-        dailySummary[dateDeceased].deceased += 1;
+        dailySummary[dateDeceased].deceased += patient.patientCount || 1;
       }
 
       if (dateReported) {
         if (!dailySummary[dateReported]) {
           dailySummary[dateReported] = _.assign({}, DAILY_SUMMARY_TEMPLATE);
         }
-        dailySummary[dateReported].reportedDeceased += 1;
+        dailySummary[dateReported].reportedDeceased += patient.patientCount || 1;
       }
     }
   }
@@ -336,22 +336,22 @@ const generatePrefectureSummary = (patients, manualPrefectureData, cruiseCounts,
     }
 
     if (patient.confirmedPatient) {
-      prefectureSummary[prefectureName].confirmed += 1;
+      prefectureSummary[prefectureName].confirmed += patient.patientCount || 1;
       if (cityName) {
         if (prefectureSummary[prefectureName].confirmedByCity[cityName]) {
-          prefectureSummary[prefectureName].confirmedByCity[cityName] += 1;
+          prefectureSummary[prefectureName].confirmedByCity[cityName] += patient.patientCount || 1;
         } else {
-          prefectureSummary[prefectureName].confirmedByCity[cityName] = 1;
+          prefectureSummary[prefectureName].confirmedByCity[cityName] = patient.patientCount || 1;
         }
       }
 
       if (patient.knownCluster && CRUISE_PASSENGER_DISEMBARKED.test(patient.knownCluster)) {
-        prefectureSummary[prefectureName].cruisePassenger += 1;
+        prefectureSummary[prefectureName].cruisePassenger += patient.patientCount || 1;
       }
     }
 
     if (patient.patientStatus == "Deceased") {
-      prefectureSummary[prefectureName].deceased += 1;
+      prefectureSummary[prefectureName].deceased += patient.patientCount || 1;
     }
 
     prefectureSummary[prefectureName].patients.push(patient);
@@ -662,9 +662,9 @@ const generateDailyStatsForPrefecture = (patients, firstDay) => {
   while (day <= lastDay) {
     const dayString = day.format("YYYY-MM-DD");
     const confirmed = _.filter(patients, (o) => o.dateAnnounced == dayString && o.confirmedPatient);
-    dailyConfirmed.push(confirmed.length);
+    dailyConfirmed.push(_.sumBy(confirmed, (v) => v.patientCount || 1));
     const deaths = _.filter(patients, (o) => o.deceasedDate == dayString && o.patientStatus == "Deceased");
-    dailyDeaths.push(deaths.length);
+    dailyDeaths.push(_.sumBy(deaths, (v) => v.patientCount || 1));
 
     const deathsAnnounced = _.filter(patients, (o) => {
       if (o.patientStatus == "Deceased") {
@@ -680,7 +680,7 @@ const generateDailyStatsForPrefecture = (patients, firstDay) => {
       }
     });
 
-    dailyDeathAnnoucements.push(deathsAnnounced.length);
+    dailyDeathAnnoucements.push(_.sumBy(deathsAnnounced, (v) => v.patientCount || 1));
     day = day.add(1, "days");
   }
   return { confirmed: dailyConfirmed, deaths: dailyDeaths, deathAnnouncements: dailyDeathAnnoucements };


### PR DESCRIPTION
Using patientCount rather than blowing up the array of patient data.

We used to output one row for every patient when internally summing the numbers. But this new wave has caused this to consume way too much memory and kill the sorting algorithm.

So we're no longer doing this so that our array length doesn't increase exponentionally